### PR TITLE
Implementación de manejo de pánicos 

### DIFF
--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -1,0 +1,54 @@
+use alloc::*;
+use alloc::vec::Vec;
+use core::fmt;
+use spin::Mutex;
+
+lazy_static! {
+    /// Used by the `print!` and `println!` macros.
+    pub static ref PRINTK_WRITER: Mutex<KernelDebugWriter> = Mutex::new(KernelDebugWriter::default());
+}
+
+#[derive(Default)]
+pub struct KernelDebugWriter {
+    buffer: Vec<u8>,
+}
+
+extern "C" {
+    fn puts_c(len: u64, c: *const u8);
+}
+
+impl KernelDebugWriter {
+    fn flush(&mut self) {
+        // Call c_puts with the string length and a pointer to its contents
+        unsafe { puts_c(self.buffer.len() as u64, self.buffer.as_ptr() as *const u8) };
+        self.buffer.clear();
+    }
+}
+
+impl fmt::Write for KernelDebugWriter {
+    fn write_str(&mut self, s: &str) -> fmt::Result {
+        // Add the bytes from `s` to the buffer
+        self.buffer.extend(s.bytes());
+        Ok(())
+    }
+}
+
+/// Like the `print!` macro in the standard library, but calls printk
+#[allow(unused_macros)]
+macro_rules! print {
+    ($($arg:tt)*) => ($crate::io::print(format_args!($($arg)*)));
+}
+
+/// Like the `print!` macro in the standard library, but calls printk
+#[allow(unused_macros)]
+macro_rules! println {
+    ($fmt:expr) => (print!(concat!($fmt, "\n")));
+    ($fmt:expr, $($arg:tt)*) => (print!(concat!($fmt, "\n"), $($arg)*));
+}
+
+pub fn print(args: fmt::Arguments) {
+    use core::fmt::Write;
+    let mut writer = PRINTK_WRITER.lock();
+    writer.write_fmt(args).unwrap();
+    writer.flush();
+}

--- a/src/lang.rs
+++ b/src/lang.rs
@@ -1,0 +1,38 @@
+use core::panic::PanicInfo;
+
+#[lang = "eh_personality"]
+#[no_mangle]
+pub extern "C" fn eh_personality() {}
+
+#[allow(dead_code)]
+extern "C" {
+    fn abort() -> !;
+    fn panic_c();
+}
+
+#[panic_handler]
+#[no_mangle]
+pub fn rust_begin_panic(info: &PanicInfo) -> ! {
+    // Print the file and line number
+    if let Some(location) = info.location() {
+        println!("Rust panic @ {}:{}",
+            location.file(), location.line());
+    }
+
+    // Print the message and a newline
+    if let Some(message) = info.message() {
+        println!("{}", message);
+    }
+
+    unsafe {
+        // In a real kernel module, we should use abort() instead of panic()
+        abort() // replace with panic_c() if you want
+    }
+}
+
+use core::alloc::Layout;
+#[cfg(not(test))]
+#[alloc_error_handler]
+pub fn alloc_error(_: Layout) -> ! {
+    unsafe { abort() }
+}

--- a/src/mem/mod.rs
+++ b/src/mem/mod.rs
@@ -1,0 +1,39 @@
+use core::alloc::{GlobalAlloc, Layout};
+
+#[derive(Default)]
+pub struct KernelAllocator;
+
+impl KernelAllocator {
+    pub const fn new() -> Self {
+        Self {}
+    }
+}
+
+// Use shim functions to avoid hardcoding the GFP_KERNEL constant
+#[allow(dead_code)]
+extern "C" {
+    fn kmalloc_c(size: usize) -> *mut u8;
+    fn kfree_c(ptr: *mut u8);
+    fn krealloc_c(ptr: *mut u8, size: usize) -> *mut u8;
+}
+
+unsafe impl GlobalAlloc for KernelAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        // A side effect of the buddy allocator is that allocations are aligned to
+        // the power-of-two that is larger than the allocation size. So if the
+        // request needs to be aligned to something larger than the allocation size,
+        // we can just pass max(size, align) to kmalloc to get something reasonable
+        // at the cost of a few extra wasted bytes.
+        use core::cmp::max;
+        let p = kmalloc_c(max(layout.size(), layout.align()));
+        if p.is_null() {
+            0 as *mut u8            
+        } else {
+            p
+        }
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, _layout: Layout) {
+        kfree_c(ptr);
+    }
+}


### PR DESCRIPTION
Implemente un gestor de pánicos personalizado, diseñado para entornos bare-metal o de bajo nivel. Incluye la función rust_begin_panic, que utiliza PanicInfo para imprimir información del pánico (archivo, línea y mensaje) antes de finalizar el programa mediante abort. También define un manejador de errores de asignación de memoria con alloc_error_handler y una función de personalidad para excepciones (eh_personality), ambas necesarias para entornos sin soporte de runtime estándar. El código es adecuado para proyectos como kernels o sistemas embebidos.
Decime si esto basta..